### PR TITLE
Merge branch 'Flake_v0.1/v0.2' to fix issues with keymap in studio

### DIFF
--- a/boards/shields/anywhy_flake/anywhy_flake.dtsi
+++ b/boards/shields/anywhy_flake/anywhy_flake.dtsi
@@ -10,92 +10,12 @@
 
     chosen {
         zmk,kscan = &kscan0;
-        zmk,physical-layout = &large_layout;
-    };
-
-    large_layout: large_layout {
-        compatible = "zmk,physical-layout";
-        display-name = "Flake L Layout";
-        transform = <&large_transform>;
-
-        keys  //                     w   h    x    y     rot    rx    ry
-            = <&key_physical_attrs 100 100    0   75       0     0     0>
-            , <&key_physical_attrs 100 100  100   75       0     0     0>
-            , <&key_physical_attrs 100 100  200   25       0     0     0>
-            , <&key_physical_attrs 100 100  300    0       0     0     0>
-            , <&key_physical_attrs 100 100  400   25       0     0     0>
-            , <&key_physical_attrs 100 100  500   25       0     0     0>
-            , <&key_physical_attrs 100 100 1000   25       0     0     0>
-            , <&key_physical_attrs 100 100 1100   25       0     0     0>
-            , <&key_physical_attrs 100 100 1200    0       0     0     0>
-            , <&key_physical_attrs 100 100 1300   25       0     0     0>
-            , <&key_physical_attrs 100 100 1400   75       0     0     0>
-            , <&key_physical_attrs 100 100 1500   75       0     0     0>
-            , <&key_physical_attrs 100 100    0  175       0     0     0>
-            , <&key_physical_attrs 100 100  100  175       0     0     0>
-            , <&key_physical_attrs 100 100  200  125       0     0     0>
-            , <&key_physical_attrs 100 100  300  100       0     0     0>
-            , <&key_physical_attrs 100 100  400  125       0     0     0>
-            , <&key_physical_attrs 100 100  500  125       0     0     0>
-            , <&key_physical_attrs 100 100 1000  125       0     0     0>
-            , <&key_physical_attrs 100 100 1100  125       0     0     0>
-            , <&key_physical_attrs 100 100 1200  100       0     0     0>
-            , <&key_physical_attrs 100 100 1300  125       0     0     0>
-            , <&key_physical_attrs 100 100 1400  175       0     0     0>
-            , <&key_physical_attrs 100 100 1500  175       0     0     0>
-            , <&key_physical_attrs 100 100    0  275       0     0     0>
-            , <&key_physical_attrs 100 100  100  275       0     0     0>
-            , <&key_physical_attrs 100 100  200  225       0     0     0>
-            , <&key_physical_attrs 100 100  300  200       0     0     0>
-            , <&key_physical_attrs 100 100  400  225       0     0     0>
-            , <&key_physical_attrs 100 100  500  225       0     0     0>
-            , <&key_physical_attrs 100 100 1000  225       0     0     0>
-            , <&key_physical_attrs 100 100 1100  225       0     0     0>
-            , <&key_physical_attrs 100 100 1200  200       0     0     0>
-            , <&key_physical_attrs 100 100 1300  225       0     0     0>
-            , <&key_physical_attrs 100 100 1400  275       0     0     0>
-            , <&key_physical_attrs 100 100 1500  275       0     0     0>
-            , <&key_physical_attrs 100 100    0  375       0     0     0>
-            , <&key_physical_attrs 100 100  100  375       0     0     0>
-            , <&key_physical_attrs 100 100  200  325       0     0     0>
-            , <&key_physical_attrs 100 100  300  300       0     0     0>
-            , <&key_physical_attrs 100 100  400  325       0     0     0>
-            , <&key_physical_attrs 100 100  500  325       0     0     0>
-            , <&key_physical_attrs 100 100 1000  325       0     0     0>
-            , <&key_physical_attrs 100 100 1100  325       0     0     0>
-            , <&key_physical_attrs 100 100 1200  300       0     0     0>
-            , <&key_physical_attrs 100 100 1300  325       0     0     0>
-            , <&key_physical_attrs 100 100 1400  375       0     0     0>
-            , <&key_physical_attrs 100 100 1500  375       0     0     0>
-            , <&key_physical_attrs 100 100  200  425       0     0     0>
-            , <&key_physical_attrs 100 100  300  400       0     0     0>
-            , <&key_physical_attrs 100 100  400  425       0     0     0>
-            , <&key_physical_attrs 100 100  500  425    1500   500   525>
-            , <&key_physical_attrs 100 100  600  470    3000   630   560>
-            , <&key_physical_attrs 100 100  900  470 (-3000)   970   560>
-            , <&key_physical_attrs 100 100 1000  425 (-1500)  1100   525>
-            , <&key_physical_attrs 100 100 1100  425       0     0     0>
-            , <&key_physical_attrs 100 100 1200  400       0     0     0>
-            , <&key_physical_attrs 100 100 1300  425       0     0     0>
-            ;
-    };
-
-    large_transform: large_transform {
-        compatible = "zmk,matrix-transform";
-        columns = <12>;
-        rows = <5>;
-        map = <
-RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)  RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11)
-RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)  RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11)
-RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)
-RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11)
-        RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)  RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10)
-        >;
+        zmk,physical-layout = &medium_layout;
     };
 
     medium_layout: medium_layout {
         compatible = "zmk,physical-layout";
-        display-name = "Flake M Layout";
+        display-name = "Flake M";
         transform = <&medium_transform>;
 
         keys  //                     w   h    x    y     rot    rx    ry
@@ -153,16 +73,16 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8) RC(3,9)
         columns = <12>;
         rows = <4>;
         map = <
+RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)  RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11)
 RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)  RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11)
 RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)
-RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11)
-        RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)  RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10)
+        RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10)
         >;
     };
 
     small_layout: small_layout {
         compatible = "zmk,physical-layout";
-        display-name = "Flake S Layout";
+        display-name = "Flake S";
         transform = <&small_transform>;
 
         keys  //                     w   h    x    y     rot    rx    ry
@@ -214,34 +134,22 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8) RC(3,9)
         columns = <10>;
         rows = <4>;
         map = <
+RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)  RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10)
 RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)  RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10)
 RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10)
 RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10)
-RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)  RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10)
         >;
     };
 
-    position_map {
+position_map {
         compatible = "zmk,physical-layout-position-map";
 
         complete;
 
-        large_layout {
-            physical-layout = <&large_layout>;
-            positions
-                = < 0  1  2  3  4  5  6  7  8  9 10 11>
-                , <12 13 14 15 16 17 18 19 20 21 22 23>
-                , <24 25 26 27 28 29 30 31 32 33 34 35>
-                , <36 37 38 39 40 41 42 43 44 45 46 47>
-                , <   48 49 50 51 52 53 54 55 56 57   >
-                ;
-        };
-
         medium_layout {
             physical-layout = <&medium_layout>;
             positions
-                = <46 47 48 49 50 51 52 53 54 55 56 57>
-                , < 0  1  2  3  4  5  6  7  8  9 10 11>
+                = < 0  1  2  3  4  5  6  7  8  9 10 11>
                 , <12 13 14 15 16 17 18 19 20 21 22 23>
                 , <24 25 26 27 28 29 30 31 32 33 34 35>
                 , <   36 37 38 39 40 41 42 43 44 45   >
@@ -251,10 +159,9 @@ RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)  RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10
         small_layout {
             physical-layout = <&small_layout>;
             positions
-                = <40 41 42 43 44 45 46 47 48 49 50 51>
-                , <52  0  1  2  3  4  5  6  7  8  9 53>
-                , <54 10 11 12 13 14 15 16 17 18 19 55>
-                , <56 20 21 22 23 24 25 26 27 28 29 57>
+                = <40  0  1  2  3  4  5  6  7  8  9 41>
+                , <42 10 11 12 13 14 15 16 17 18 19 43>
+                , <44 20 21 22 23 24 25 26 27 28 29 45>
                 , <   30 31 32 33 34 35 36 37 38 39   >
                 ;
         };

--- a/boards/shields/anywhy_flake/anywhy_flake.keymap
+++ b/boards/shields/anywhy_flake/anywhy_flake.keymap
@@ -108,7 +108,6 @@
 
         base {
             bindings = <
-&kp ESC    &kp N1  &kp N2    &kp N3    &kp N4     &kp N5            &kp N6  &kp N7     &kp N8     &kp N9    &kp N0     &kp MINUS
 &kp ENTER  &kp Q   &kp W     &kp E     &kp R      &kp T             &kp Y   &kp U      &kp I      &kp O     &kp P      &kp BSPC
 &kp TAB    &kp A   &kp S     &kp D     &kp F      &kp G             &kp H   &kp J      &kp K      &kp L     &kp SEMI   &kp APOS
 &kp LBKT   &kp Z   &kp X     &kp C     &kp V      &kp B             &kp N   &kp M      &kp COMMA  &kp DOT   &kp FSLH   &kp RBKT
@@ -118,7 +117,6 @@
 
         num {
             bindings = <
-&none  &none     &none          &none      &none      &none            &none      &none   &none   &none   &none      &none
 &none  &kp ESC   &kp BACKSPACE  &kp TAB    &kp ENTER  &kp DEL          &kp GRAVE  &kp N7  &kp N8  &kp N9  &kp MINUS  &none
 &none  &kp LGUI  &kp LALT       &kp LCTRL  &kp LSHFT  &kp LBKT         &kp EQUAL  &kp N4  &kp N5  &kp N6  &kp N0     &none
 &none  &kp LEFT  &kp DOWN       &kp UP     &kp RIGHT  &kp RBKT         &kp SQT    &kp N1  &kp N2  &kp N3  &kp BSLH   &none
@@ -128,12 +126,17 @@
 
         fn {
             bindings = <
-&none  &none    &none   &none   &none   &none                  &none  &none       &none         &none         &none         &none
 &none  &kp F12  &kp F7  &kp F8  &kp F9  &soft_off              &bt2   &kp C_MUTE  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_BRI_UP  &none
 &none  &kp F10  &kp F4  &kp F5  &kp F6  &kp CAPS               &bt1   &kp RSHFT   &kp RCTRL     &kp RALT      &kp RGUI      &none
 &none  &kp F11  &kp F1  &kp F2  &kp F3  &studio_unlock         &bt0   &kp C_PP    &kp C_PREV    &kp C_NEXT    &kp C_BRI_DN  &none
                 &trans  &trans  &trans  &trans          &none  &none  &trans      &trans        &trans        &trans
             >;
         };
+
+        extra1 { status = "reserved"; };
+        extra2 { status = "reserved"; };
+        extra3 { status = "reserved"; };
+        extra4 { status = "reserved"; };
+        extra5 { status = "reserved"; };
     };
 };

--- a/boards/shields/anywhy_flake/anywhy_flake_left.overlay
+++ b/boards/shields/anywhy_flake/anywhy_flake_left.overlay
@@ -15,6 +15,5 @@
         , <&pro_micro 9  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-        , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         ;
 };

--- a/boards/shields/anywhy_flake/anywhy_flake_right.overlay
+++ b/boards/shields/anywhy_flake/anywhy_flake_right.overlay
@@ -1,9 +1,5 @@
 #include "anywhy_flake.dtsi"
 
-&large_transform {
-    col-offset = <6>;
-};
-
 &medium_transform {
     col-offset = <6>;
 };
@@ -27,6 +23,5 @@
         , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         , <&pro_micro 9  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         , <&pro_micro 8  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-        , <&pro_micro 7  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
         ;
 };


### PR DESCRIPTION
I was trying to get the Flake setup with zmk studio for the last few days racking my brain over why my keymap didn't line up in studio. it keps removing my rop row or shifting the whole row.

I discovered that the medium keymap/transform started with `RC(1,0)` instead of `RC(0,0)`. After fixing it I finally saw that you had a branch with this fix already. So I think this should be merged in.

branch : https://github.com/anywhy-io/flake-zmk-module/tree/Flake_v0.1/v0.2